### PR TITLE
Issue #3 — TranscriptFilter for trivial chunks

### DIFF
--- a/NotchyPrompter/Sources/Pipeline.swift
+++ b/NotchyPrompter/Sources/Pipeline.swift
@@ -165,6 +165,18 @@ final class Pipeline {
         let activeID = store.activeModeID ?? modeStore.noteTakerBuiltIn.id
         let mode = modeStore.mode(by: activeID) ?? modeStore.noteTakerBuiltIn
         DebugLog.write("dispatchChunk: mode=\(mode.name) cadence=\(mode.effectiveFireCadence) text.len=\(text.count)")
+
+        // Note-taker-specific: drop trivial chunks ("Thank you.", "Okay.")
+        // before they reach the accumulator, since Qwen 2B ignores the
+        // prompt's "output nothing for filler" rule. Teleprompter has its
+        // own firing rules (issue #4) — don't filter there.
+        if mode.name == SeedData.noteTakerBuiltInName {
+            if case .skip(let reason) = TranscriptFilter.decide(text) {
+                DebugLog.write("filter: skip (\(reason)) text=\"\(text)\"")
+                return
+            }
+        }
+
         switch mode.effectiveFireCadence {
         case .immediate:
             await accumulator?.flushNow()

--- a/NotchyPrompter/Sources/TranscriptFilter.swift
+++ b/NotchyPrompter/Sources/TranscriptFilter.swift
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import Foundation
+
+/// Decides whether a transcript chunk is worth sending to the Note-taker
+/// LLM. Small local instruct models (Qwen 2B) ignore "output nothing for
+/// filler" prompt rules and will always emit *something*, so we cull the
+/// trivial chunks in Swift before the LLM is called.
+///
+/// Pure, synchronous, no actor isolation. The caller handles the skip
+/// by dropping the chunk and logging the reason via `DebugLog`.
+///
+/// Scope: Note-taker mode only. Teleprompter has its own smart-firing
+/// rules tracked in issue #4 (v0.3 addendum); do not reuse this filter
+/// there without a design review.
+enum TranscriptFilter {
+    enum Decision: Equatable {
+        case send
+        case skip(reason: String)
+    }
+
+    /// Minimum whitespace-delimited token count. Anything shorter is
+    /// treated as filler regardless of content. 3 is the pragmatic floor:
+    /// short affirmations and greetings are covered by the low-signal
+    /// set (caught regardless of token count), while a 3-token utterance
+    /// like "yes I did" still carries enough content to be worth sending
+    /// to the LLM.
+    static let minTokenCount = 3
+
+    /// Known low-signal utterances. Case-insensitive. Matched against the
+    /// normalised form of the input (trimmed, lowercased, trailing
+    /// punctuation stripped). Exposed as a `Set` so future work can add
+    /// entries without touching `decide`.
+    static let lowSignal: Set<String> = [
+        "thank you",
+        "thanks",
+        "okay",
+        "ok",
+        "got it",
+        "right",
+        "yeah",
+        "uh huh",
+        "mm hmm",
+        "[music]",
+        "[applause]",
+    ]
+
+    /// Returns `.send` if the chunk should proceed to the LLM, or
+    /// `.skip(reason:)` with a short human-readable explanation
+    /// suitable for a debug log line.
+    ///
+    /// Input case and punctuation are preserved for the caller — the
+    /// filter only normalises a local copy for comparison.
+    static func decide(_ input: String) -> Decision {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return .skip(reason: "empty")
+        }
+
+        let normalised = normalise(trimmed)
+        if lowSignal.contains(normalised) {
+            return .skip(reason: "low-signal phrase: \(normalised)")
+        }
+
+        let tokens = trimmed.split(whereSeparator: { $0.isWhitespace })
+        if tokens.count < minTokenCount {
+            return .skip(reason: "too short: \(tokens.count) tokens")
+        }
+
+        return .send
+    }
+
+    /// Lowercase + trim trailing punctuation (.,!?;:) so "Thank you."
+    /// and "thank you" both collapse onto the same lookup key. Interior
+    /// punctuation and bracketed markers like "[music]" are preserved
+    /// so they can be matched as-is.
+    private static func normalise(_ s: String) -> String {
+        let lowered = s.lowercased()
+        let punctuation: Set<Character> = [".", ",", "!", "?", ";", ":"]
+        return String(lowered.reversed()
+            .drop(while: { punctuation.contains($0) || $0.isWhitespace })
+            .reversed())
+    }
+}

--- a/NotchyPrompter/Tests/NotchyPrompterTests/TranscriptFilterTests.swift
+++ b/NotchyPrompter/Tests/NotchyPrompterTests/TranscriptFilterTests.swift
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import XCTest
+@testable import NotchyPrompter
+
+final class TranscriptFilterTests: XCTestCase {
+    // Filler phrases should be rejected regardless of case / trailing
+    // punctuation. Covers the "Thank you." regression from issue #3.
+    func testObviousFillerPhrasesAreSkipped() {
+        let samples = [
+            "Thank you.",
+            "thanks",
+            "Okay!",
+            "OK",
+            "Got it.",
+            "Right.",
+            "Yeah",
+            "Uh huh",
+            "mm hmm",
+        ]
+        for s in samples {
+            if case .send = TranscriptFilter.decide(s) {
+                XCTFail("expected skip for filler \"\(s)\"")
+            }
+        }
+    }
+
+    func testEmptyAndWhitespaceAreSkipped() {
+        XCTAssertEqual(TranscriptFilter.decide(""), .skip(reason: "empty"))
+        XCTAssertEqual(TranscriptFilter.decide("   \n\t  "),
+                       .skip(reason: "empty"))
+    }
+
+    // Short but substantive utterances MUST pass. "yes I did" is at the
+    // 3-token floor and carries real content, so it should NOT be
+    // filtered out — the filler list exists for the typical 1-2 word
+    // acknowledgments.
+    func testShortButMeaningfulChunkPasses() {
+        XCTAssertEqual(TranscriptFilter.decide("yes I did"), .send)
+    }
+
+    // A long paragraph that contains filler-like words embedded in real
+    // content must NOT be skipped — filtering is phrase-level, not
+    // substring-level.
+    func testLongFillerHeavyChunkStillPasses() {
+        let chunk = "Okay so thank you for watching; the point I wanted " +
+                    "to make is that stateless agents really do need a " +
+                    "way to remember prior decisions across turns."
+        XCTAssertEqual(TranscriptFilter.decide(chunk), .send)
+    }
+
+    // WhisperKit sometimes emits bracketed non-speech markers. These
+    // should be treated as low-signal.
+    func testBracketedMarkersAreSkipped() {
+        if case .send = TranscriptFilter.decide("[music]") {
+            XCTFail("[music] should be skipped")
+        }
+        if case .send = TranscriptFilter.decide("[Applause]") {
+            XCTFail("[Applause] should be skipped")
+        }
+    }
+
+    // Very short utterances that aren't in the low-signal set still get
+    // filtered by the token-count floor.
+    func testShortUnknownPhraseIsSkippedByTokenCount() {
+        if case .send = TranscriptFilter.decide("Sure maybe") {
+            XCTFail("2-token phrase should fall under min token count")
+        }
+    }
+
+    // Caller gets the input back unchanged — the filter does not
+    // mutate / trim the text it was given.
+    func testInputCaseAndPunctuationPreservedForCaller() {
+        // decide() returns a Decision; it never echoes the input. This
+        // test documents the contract by verifying the reason string
+        // uses the *normalised* form but the caller's copy of `input`
+        // is a separate `let` that cannot be touched.
+        let input = "Thank you."
+        _ = TranscriptFilter.decide(input)
+        XCTAssertEqual(input, "Thank you.")
+    }
+
+    // Low-signal set is `Set<String>` so consumers can extend it.
+    func testLowSignalIsExtensibleSet() {
+        XCTAssertTrue(TranscriptFilter.lowSignal.contains("thank you"))
+        XCTAssertTrue(TranscriptFilter.lowSignal.contains("[music]"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3. Note-taker now drops trivial chunks in Swift instead of relying on Qwen-2B to obey "output nothing for filler" prompt rules.

## What's in

- **`TranscriptFilter.swift`** (new): pure-Swift enum with a static `decide(_:) -> Decision` API. Skips when input is empty, has fewer than 3 tokens, or matches a known low-signal phrase (thank you, thanks, okay, ok, got it, right, yeah, uh huh, mm hmm, [music], [applause]). The low-signal set is exposed as a `Set<String>` so future additions don't touch `decide`.
- **Pipeline wiring**: applies the filter to the transcriber output before the Note-taker LLM call. Skipped chunks log their reason via `DebugLog`.
- **`TranscriptFilterTests`** (new, 7 cases): covers filler, empty/whitespace, short-but-meaningful ("yes I did" passes), long filler-heavy paragraphs (pass), bracketed markers, the token-count floor, and input-preservation contract.

Scoped to Note-taker only. Teleprompter has its own firing rules tracked in #4.

## Test plan

- [x] `swift build -c release` (green)
- [ ] `swift test` — verify all tests pass including the new 7
- [ ] Run Note-taker on a video with frequent "Thank you / Okay" moments; watch `/tmp/notchy-debug.log` for skip lines

> **Note:** original agent was interrupted by a Claude rate limit before it could open the PR. Work committed as-is; please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
