### PR TITLE
Issue #6 — Ollama installed-model picker + pre-flight

### DIFF
--- a/NotchyPrompter/Sources/OllamaModelsProbe.swift
+++ b/NotchyPrompter/Sources/OllamaModelsProbe.swift
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import Foundation
+
+/// Lists models already pulled into a local Ollama daemon by hitting
+/// `GET /api/tags`. Used to populate the Settings model picker and for
+/// pre-flight validation before the pipeline starts streaming.
+struct OllamaModelsProbe {
+    let baseURL: URL
+    let session: URLSession
+
+    init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    enum ProbeError: Error, LocalizedError, Equatable {
+        case unreachable(String)
+        case notFound
+        case badStatus(Int)
+        case malformed
+
+        var errorDescription: String? {
+            switch self {
+            case .unreachable(let msg):
+                return "Couldn't reach Ollama: \(msg)"
+            case .notFound:
+                return "Ollama responded 404 (is `/api/tags` served?)"
+            case .badStatus(let code):
+                return "Ollama returned HTTP \(code)"
+            case .malformed:
+                return "Ollama returned malformed JSON"
+            }
+        }
+    }
+
+    /// Fetches the installed model list. Returns names as Ollama reports them
+    /// (e.g. `qwen3.5:2b`). Sorted alphabetically for stable UI.
+    func listInstalled() async throws -> [String] {
+        var req = URLRequest(url: baseURL.appendingPathComponent("api/tags"))
+        req.httpMethod = "GET"
+        req.timeoutInterval = 5
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch {
+            throw ProbeError.unreachable(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ProbeError.unreachable("no HTTP response")
+        }
+        if http.statusCode == 404 { throw ProbeError.notFound }
+        guard 200..<300 ~= http.statusCode else {
+            throw ProbeError.badStatus(http.statusCode)
+        }
+
+        return try Self.parseNames(data)
+    }
+
+    /// Exposed for tests: decodes the `/api/tags` body into sorted model names.
+    static func parseNames(_ data: Data) throws -> [String] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = obj["models"] as? [[String: Any]]
+        else {
+            throw ProbeError.malformed
+        }
+        let names = models.compactMap { $0["name"] as? String }
+        return names.sorted()
+    }
+}

--- a/NotchyPrompter/Sources/Pipeline.swift
+++ b/NotchyPrompter/Sources/Pipeline.swift
@@ -51,6 +51,38 @@ final class Pipeline {
         self.capture = cap
         vm.isRunning = true
         vm.setStatus("starting…")
+
+        // Ollama pre-flight: probe `/api/tags` and fail fast with a clear
+        // message if the selected model isn't installed. Claude path skips.
+        if store.backend == .ollama, let url = URL(string: store.ollamaURL) {
+            let selectedModel = store.ollamaModel
+            let probe = OllamaModelsProbe(baseURL: url)
+            Task { [weak self] in
+                do {
+                    let installed = try await probe.listInstalled()
+                    guard let self else { return }
+                    if !installed.contains(selectedModel) {
+                        self.vm.setStatus("Ollama model '\(selectedModel)' isn't installed. Run `ollama pull \(selectedModel)`.")
+                        self.stop()
+                        return
+                    }
+                    self.continueStart(capture: cap, transcriber: t, client: client)
+                } catch {
+                    // Probe failure is non-fatal; let the stream attempt
+                    // surface the real error. This covers Ollama servers that
+                    // don't expose `/api/tags` for whatever reason.
+                    self?.continueStart(capture: cap, transcriber: t, client: client)
+                }
+            }
+            return
+        }
+
+        continueStart(capture: cap, transcriber: t, client: client)
+    }
+
+    private func continueStart(capture cap: AudioCapture,
+                               transcriber t: Transcriber,
+                               client: LLMClient) {
         let activeID = store.activeModeID ?? modeStore.noteTakerBuiltIn.id
         let initial = modeStore.mode(by: activeID) ?? modeStore.noteTakerBuiltIn
         sessionRecorder.startSession(initialMode: initial)

--- a/NotchyPrompter/Sources/SettingsView.swift
+++ b/NotchyPrompter/Sources/SettingsView.swift
@@ -6,6 +6,9 @@ struct BackendSettingsView: View {
     var onStart: () -> Void
     var onStop: () -> Void
     @State private var showKey = false
+    @State private var ollamaModels: [String] = []
+    @State private var ollamaProbeError: String? = nil
+    @State private var ollamaProbeLoading = false
 
     var body: some View {
         Form {
@@ -40,11 +43,58 @@ struct BackendSettingsView: View {
                 Section("Ollama") {
                     TextField("Base URL", text: $store.ollamaURL)
                         .textFieldStyle(.roundedBorder)
-                    TextField("Model", text: $store.ollamaModel)
-                        .textFieldStyle(.roundedBorder)
-                    Text("Start with `ollama serve` and `ollama pull \(store.ollamaModel)`.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .onChange(of: store.ollamaURL) { _, _ in
+                            Task { await refreshOllamaModels() }
+                        }
+
+                    if ollamaProbeError == nil && !ollamaModels.isEmpty {
+                        HStack {
+                            Picker("Model", selection: $store.ollamaModel) {
+                                ForEach(modelPickerOptions, id: \.self) { name in
+                                    Text(name).tag(name)
+                                }
+                            }
+                            Button {
+                                Task { await refreshOllamaModels() }
+                            } label: {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(ollamaProbeLoading)
+                        }
+                        TextField("Or type a model name", text: $store.ollamaModel)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        HStack {
+                            TextField("Model", text: $store.ollamaModel)
+                                .textFieldStyle(.roundedBorder)
+                            Button {
+                                Task { await refreshOllamaModels() }
+                            } label: {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(ollamaProbeLoading)
+                        }
+                    }
+
+                    if let err = ollamaProbeError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else if !ollamaModels.isEmpty,
+                              !ollamaModels.contains(store.ollamaModel) {
+                        Text("Model '\(store.ollamaModel)' isn't installed. Run `ollama pull \(store.ollamaModel)`.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else {
+                        Text("Start with `ollama serve` and `ollama pull \(store.ollamaModel)`.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .task {
+                    await refreshOllamaModels()
                 }
             }
 
@@ -82,5 +132,33 @@ struct BackendSettingsView: View {
         }
         .formStyle(.grouped)
         .frame(width: 520, height: 560)
+    }
+
+    /// Picker options: installed models, plus the current value if it isn't in
+    /// the list (so the user's custom entry stays selected).
+    private var modelPickerOptions: [String] {
+        if store.ollamaModel.isEmpty || ollamaModels.contains(store.ollamaModel) {
+            return ollamaModels
+        }
+        return ollamaModels + [store.ollamaModel]
+    }
+
+    private func refreshOllamaModels() async {
+        guard let url = URL(string: store.ollamaURL) else {
+            ollamaProbeError = "Invalid Ollama URL: \(store.ollamaURL)"
+            ollamaModels = []
+            return
+        }
+        ollamaProbeLoading = true
+        defer { ollamaProbeLoading = false }
+        do {
+            let probe = OllamaModelsProbe(baseURL: url)
+            let names = try await probe.listInstalled()
+            ollamaModels = names
+            ollamaProbeError = nil
+        } catch {
+            ollamaModels = []
+            ollamaProbeError = "Couldn't reach Ollama at \(store.ollamaURL). Is `ollama serve` running?"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #6. Replaces the hardcoded Ollama model default with a real picker populated from the daemon.

## What's in

- **`OllamaModelsProbe.swift`** (new): `listInstalled()` hits `GET <baseURL>/api/tags` and returns sorted model names. Clear error types: `unreachable`, `notFound`, `badStatus(Int)`, `malformed`.
- **Settings UI**: when Ollama is the selected backend, the model field becomes a `Picker` populated by the probe, with a refresh button. Falls back to a plain text field + "Is `ollama serve` running?" status line when the probe fails.
- **Pipeline pre-flight**: before streaming, checks whether the selected model is in the installed list. If not, surfaces "Run `ollama pull <name>`" in the status line instead of failing on the first `/api/chat` call.

Claude path unchanged.

## Test plan

- [x] `swift build -c release` (green)
- [ ] Open Settings → Backend with Ollama selected; confirm picker lists locally installed models
- [ ] Stop `ollama serve` and open Settings; confirm fallback text field + error status
- [ ] Select a model that isn't installed and click Start; confirm the "run `ollama pull`" hint

> **Note:** original agent was interrupted by a Claude rate limit before it could open the PR. Work committed as-is; please review before merging. Unit tests for `OllamaModelsProbe.parseNames` are NOT in this PR — consider a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
