### PR TITLE
Issue #5 — Instrument mode-change log path (diagnostic PR)

### DIFF
--- a/NotchyPrompter/Sources/Pipeline.swift
+++ b/NotchyPrompter/Sources/Pipeline.swift
@@ -14,7 +14,10 @@ final class Pipeline {
     var postSessionHook: ((Session) async -> Void)?
 
     func recordModeChangeIfRunning(_ mode: Mode) {
-        guard vm.isRunning else { return }
+        guard vm.isRunning else {
+            DebugLog.write("recordModeChangeIfRunning skipped: vm.isRunning=false, mode=\(mode.name)")
+            return
+        }
         sessionRecorder.recordModeChange(mode)
     }
 

--- a/NotchyPrompter/Sources/SessionRecorder.swift
+++ b/NotchyPrompter/Sources/SessionRecorder.swift
@@ -78,11 +78,21 @@ final class SessionRecorder {
     }
 
     private func appendLog(_ line: String) {
-        guard let url = liveLogURL, let data = line.data(using: .utf8) else { return }
-        if let handle = try? FileHandle(forWritingTo: url) {
+        guard let url = liveLogURL else {
+            DebugLog.write("SessionRecorder.appendLog skipped: liveLogURL is nil")
+            return
+        }
+        guard let data = line.data(using: .utf8) else {
+            DebugLog.write("SessionRecorder.appendLog skipped: UTF-8 encode failed")
+            return
+        }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
             defer { try? handle.close() }
-            try? handle.seekToEnd()
-            try? handle.write(contentsOf: data)
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            DebugLog.write("SessionRecorder.appendLog error: \(error.localizedDescription) url=\(url.path)")
         }
     }
 

--- a/NotchyPrompter/Tests/NotchyPrompterTests/SessionRecorderTests.swift
+++ b/NotchyPrompter/Tests/NotchyPrompterTests/SessionRecorderTests.swift
@@ -57,6 +57,39 @@ final class SessionRecorderTests: XCTestCase {
         XCTAssertTrue(s2.id.hasSuffix("-2"))
     }
 
+    // Regression test for issue #5: switching mode mid-session must append
+    // the [mode: X] line to the live .log file, not just the in-memory event
+    // list that eventually lands in the .json on Stop.
+    func testModeChangeAppearsInLiveLog() throws {
+        let t = Date(timeIntervalSince1970: 1_700_000_000)
+        let r = SessionRecorder(directory: tmpDir, clock: { t })
+        let noteTaker = Mode(id: UUID(), name: "Note-taker", systemPrompt: "",
+                             attachedContextIDs: [], modelOverride: nil,
+                             maxTokens: nil, isBuiltIn: true, defaults: nil)
+        let teleprompter = Mode(id: UUID(), name: "Teleprompter", systemPrompt: "",
+                                attachedContextIDs: [], modelOverride: nil,
+                                maxTokens: nil, isBuiltIn: true, defaults: nil)
+
+        r.startSession(initialMode: noteTaker)
+        r.recordTranscript("first thing they said", durationMs: 1000)
+        r.recordModeChange(teleprompter)
+        r.recordTranscript("something after the switch", durationMs: 1000)
+
+        guard let logURL = r.currentLogURL else {
+            XCTFail("expected SessionRecorder to expose a live log URL")
+            return
+        }
+        let contents = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertTrue(contents.contains("[mode: Note-taker]"),
+                      "initial mode header missing — got:\n\(contents)")
+        XCTAssertTrue(contents.contains("[mode: Teleprompter]"),
+                      "mode-change line missing from live log — got:\n\(contents)")
+        XCTAssertTrue(contents.contains("them: first thing they said"),
+                      "transcript before mode change missing — got:\n\(contents)")
+        XCTAssertTrue(contents.contains("them: something after the switch"),
+                      "transcript after mode change missing — got:\n\(contents)")
+    }
+
     func testListSessionsOrderedByStartDesc() throws {
         var t = Date(timeIntervalSince1970: 1_700_000_000)
         let r = SessionRecorder(directory: tmpDir, clock: { t })


### PR DESCRIPTION
## Summary

Intermediate step toward closing #5. The bug — mid-session mode switches missing from the live `.log` — is **NOT reproducible in a unit test**, so this PR ships instrumentation that will identify the root cause when you run the live app.

## What's in

- **`SessionRecorder.appendLog`**: stops swallowing `FileHandle` errors with `try?`. Every failure path (nil URL, encoding, open, seek, write) now writes a diagnostic line to `/tmp/notchy-debug.log` via `DebugLog`.
- **`Pipeline.recordModeChangeIfRunning`**: logs a line when the `vm.isRunning` guard short-circuits, so we can tell whether the callsite fires at all vs. the write fails downstream.
- **`testModeChangeAppearsInLiveLog`** (new regression test): drives `SessionRecorder.startSession` → `recordModeChange` in isolation and asserts the `.log` contents. **This test passes on `main`**, which tells us the `SessionRecorder` code path itself is correct — the live-app bug is happening above `SessionRecorder` (in `Pipeline`) or is a timing/state issue unique to the live `@MainActor` runtime.

## How to find the root cause

1. Pull this branch and rebuild.
2. Start a session in Note-taker.
3. Switch to Teleprompter from the menu bar mid-session.
4. Click Stop.
5. Inspect `/tmp/notchy-debug.log`:
   - If you see `recordModeChangeIfRunning skipped: vm.isRunning=false` → the Pipeline guard is firing when it shouldn't; root cause is MainActor / timing of `vm.isRunning`.
   - If you see `SessionRecorder.appendLog error: …` → the file-write path is failing; root cause is whatever error is printed.
   - If neither shows up → the mode-select callback isn't calling `pipeline.recordModeChangeIfRunning` at all; look at `AppDelegate.selectMode` or the menu wiring.

Paste the relevant lines into the issue and we'll ship the actual fix in a follow-up.

## Test plan

- [x] `swift test --filter SessionRecorderTests` — 4/4 pass (including the new regression)
- [x] `swift build -c release` — green
- [ ] User reproduces the bug with the live app and pastes the DebugLog output

> **Why not ship a speculative fix?** CLAUDE.md emphasises not fixing symptoms without understanding root cause. Until the DebugLog tells us which of the three branches above is firing, any "fix" is a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
