### PR TITLE
Issue #7 — exclude macOS speech daemons from SCK mix (supersedes #14)

### DIFF
--- a/NotchyPrompter/Sources/AudioCapture.swift
+++ b/NotchyPrompter/Sources/AudioCapture.swift
@@ -10,7 +10,25 @@ import ScreenCaptureKit
 /// No virtual audio driver needed — SCK captures what the speakers would
 /// play. `excludesCurrentProcessAudio = true` keeps our own output out of
 /// the stream.
+///
+/// We also exclude macOS speech daemons (dictation, Siri TTS, CoreSpeech) via
+/// `SCContentFilter.excludingApplications` so recognition chirps and TTS
+/// playback don't bleed into the capture. See
+/// `docs/superpowers/research-2026-04-19-m13v-feedback.md` for the API
+/// reference and bundle-ID list.
 final class AudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
+    /// macOS processes that play speech-synthesis / dictation audio and
+    /// therefore end up in the SCK system mix. Excluding them at the
+    /// content-filter level stops the leak described in issue #7.
+    private static let speechDaemonBundleIDs: Set<String> = [
+        "com.apple.speech.speechsynthesisd",                 // modern TTS daemon
+        "com.apple.speech.synthesisserver",                  // legacy TTS
+        "com.apple.SpeechRecognitionCore.speechrecognitiond", // dictation
+        "com.apple.corespeechd",                             // CoreSpeech framework
+        "com.apple.SiriTTSService",                          // Siri TTS
+        "com.apple.assistantd",                              // Siri orchestrator
+    ]
+
     private var stream: SCStream?
     private var converter: AVAudioConverter?
     private var outFormat: AVAudioFormat?
@@ -28,18 +46,34 @@ final class AudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked
     }
 
     func start() async throws {
+        // Background daemons don't own on-screen windows, so request the
+        // full running-app list — otherwise speechsynthesisd / corespeechd
+        // never appear in `content.applications` and the exclusion below is
+        // a no-op.
         let content = try await SCShareableContent.excludingDesktopWindows(
-            false, onScreenWindowsOnly: true
+            false, onScreenWindowsOnly: false
         )
         guard let display = content.displays.first else {
             throw NSError(domain: "AudioCapture", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "no display found"])
         }
 
+        let excludedApps = content.applications.filter {
+            Self.speechDaemonBundleIDs.contains($0.bundleIdentifier)
+        }
+        if excludedApps.isEmpty {
+            NSLog("AudioCapture: no speech daemons found to exclude (Siri/dictation may be disabled)")
+        } else {
+            let ids = excludedApps.map(\.bundleIdentifier).joined(separator: ", ")
+            NSLog("AudioCapture: excluding %d speech daemons: %@", excludedApps.count, ids)
+        }
+
         // Audio-only filter: attach to a display but request audio capture.
+        // SCK applies `excludingApplications` to the audio mix as well as
+        // video (WWDC22 session 10155), so this gates speech-daemon output.
         let filter = SCContentFilter(
             display: display,
-            excludingApplications: [],
+            excludingApplications: excludedApps,
             exceptingWindows: []
         )
 


### PR DESCRIPTION
## Summary

Closes #7. Supersedes PR #14 (research-only; its "no public SCK API filters by audio source" conclusion was wrong — per-app audio filtering has existed since macOS 13.0, WWDC22 session 10155).

Our existing SCK filter passed `excludingApplications: []`, so recognition chirps, Siri confirmations, and TTS playback from the macOS speech daemons ended up in the capture stream alongside real meeting audio. This PR excludes those processes at filter-build time.

## What's in

- **`AudioCapture.swift`**:
  - New `speechDaemonBundleIDs` set covering the TTS / dictation / CoreSpeech / Siri daemons:
    - `com.apple.speech.speechsynthesisd` (modern TTS)
    - `com.apple.speech.synthesisserver` (legacy TTS name)
    - `com.apple.SpeechRecognitionCore.speechrecognitiond` (dictation)
    - `com.apple.corespeechd` (CoreSpeech framework daemon)
    - `com.apple.SiriTTSService`
    - `com.apple.assistantd`
  - `SCShareableContent.excludingDesktopWindows(_:onScreenWindowsOnly:)` now passes `false` for `onScreenWindowsOnly` — background daemons don't own on-screen windows, so without this change they never appear in `content.applications` and the exclusion is a no-op.
  - Filter those daemons out of `content.applications`, pass the set to `SCContentFilter(..., excludingApplications:, ...)`.
  - One-shot startup `NSLog` names which daemons were excluded, so we can tell from Console whether the fix engaged on a given machine (Siri/dictation disabled → empty list, just a diagnostic line).

Leaves `excludesCurrentProcessAudio = false` alone — CLAUDE.md flags it as intentional-while-debugging; separate concern.

## What this does NOT fix

User-side routing — Live Listen, conferencing apps with "monitor my mic", DAWs with monitor-input enabled, aggregate devices (BlackHole / Loopback) routing mic → default output. Those leak regardless of any app-level SCK filter; they need the user to disable the routing, or Apple's post-14.4 `AudioHardwareCreateProcessTap` API (bigger rewrite, deferred).

Research (`docs/superpowers/research-2026-04-19-m13v-feedback.md` on main) documents the long-term migration path.

## Test plan

- [x] `swift build -c release` — green
- [x] `swift test` — 39/39 pass (no new unit tests; SCK integration code needs live verification)
- [ ] `./NotchyPrompter/build.sh && open NotchyPrompter/NotchyPrompter.app`
- [ ] Console.app, filter for "AudioCapture" — look for `AudioCapture: excluding N speech daemons: <ids>` on startup
- [ ] Trigger macOS Dictation (fn-fn) and speak; verify the recognition chirp does NOT appear in the transcript
- [ ] Run a live session; confirm audio capture still works (not over-filtered)

> **Heads-up on TCC.** This doesn't change the bundle signature, so the Screen Recording grant should survive the rebuild. If it doesn't, run `tccutil reset ScreenCapture com.mhlaghari.notchyprompter` once and re-grant.

## Follow-up

- **Close PR #14** — this PR supersedes it. The bits of PR #14 worth keeping (user-facing README Known-limitations caveat about Live Listen / aggregate devices) can be folded into a follow-up doc PR or this PR on request.
- Long-term: migrate to `AudioHardwareCreateProcessTap` (see research doc § "Longer-term alternative").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
